### PR TITLE
Upstream travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,56 +1,44 @@
 language: python
 python:
-  - 3.7
+  - 2.7
+  - 3.6.10
+env:
+  - BUILD_TYPE="Release"
 
 before_install:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - source "$HOME/miniconda/etc/profile.d/conda.sh"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda config --add channels conda-forge
-  - conda update -q conda
-  - conda info -a
-  - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION nose lapack compilers netcdf4 netcdf-fortran xarray scipy matplotlib
+  - sudo apt-get update
+  - sudo apt-get install gfortran liblapack-pic liblapack-dev libnetcdf-dev libnetcdff-dev
+  - pip install netCDF4
+  - pip install xarray
+  - pip install scipy
   - git clone --branch=master --depth=100 --quiet git://github.com/clawpack/clawpack
   - cd clawpack
   - git submodule init
-  - git submodule update -j 6
+  - git submodule update
   - rm -rf geoclaw
   - ln -s ../ geoclaw
   # Print versions being used
   - python -c "import numpy; print(numpy.__version__)"
   - python -c "import netCDF4; print(netCDF4.__version__)"
 
-install: skip
-
-before_script:
-  - conda activate test-env
+install:
   - export PYTHONPATH=${PWD}:$PYTHONPATH
   - export CLAW=${PWD}
   - export FC=gfortran
-# needed to remove the -fstack-protector flag that conda's gfortran uses by default
-  - unset FFLAGS
-# below paths are needed for netcdf test and multilayer
-  - export NETCDF4_DIR=$HOME/miniconda/envs/test-env
-  - export LIB_PATHS=$HOME/miniconda/envs/test-env/lib
+  - export NETCDF4_DIR=/usr
+
+before_script:
+  # Print CPU info for debugging purposes:
   - cat /proc/cpuinfo
-  - python -c "import numpy; print(numpy.__version__)"
   - gfortran -v
+  - /usr/bin/f95 -v
   - echo "PYTHONPATH="$PYTHONPATH
   - echo "CLAW="$CLAW
   - echo "FC="$FC
   - echo "NETCDF4_DIR="$NETCDF4_DIR
-  - echo "LIB_PATHS="$LIB_PATHS
-  - echo "FFLAGS="$FFLAGS
-  - which $FC
-  - cd $CLAW/geoclaw
 
 script:
+  - cd $CLAW/geoclaw
   - nosetests -sv
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - pip install netCDF4
   - pip install xarray
   - pip install scipy
+  - pip install matplotlib
   - git clone --branch=master --depth=100 --quiet git://github.com/clawpack/clawpack
   - cd clawpack
   - git submodule init

--- a/src/2d/shallow/Makefile.geoclaw
+++ b/src/2d/shallow/Makefile.geoclaw
@@ -144,8 +144,8 @@ COMMON_SOURCES += \
   $(GEOLIB)/amr2.f90 \
   $(GEOLIB)/fgmax_read.f90 \
   $(GEOLIB)/fgmax_frompatch.f90 \
-  $(GEOLIB)/fgmax_values_wind.f90 \
   $(GEOLIB)/fgmax_interp.f90 \
+  $(GEOLIB)/fgmax_values.f90 \
   $(GEOLIB)/fgmax_finalize.f90 \
   $(GEOLIB)/check.f \
   $(GEOLIB)/restrt.f \

--- a/tests/bowl_slosh/regression_tests.py
+++ b/tests/bowl_slosh/regression_tests.py
@@ -58,7 +58,7 @@ class BowlSloshTest(test.GeoClawRegressionTest):
 
         # Perform tests
         self.check_gauges(save=save, gauge_id=1, indices=(2, 3))
-#         self.check_fgmax(save=save)
+        self.check_fgmax(save=save)
         self.success = True
 
 

--- a/tests/bowl_slosh/setrun.py
+++ b/tests/bowl_slosh/setrun.py
@@ -388,7 +388,7 @@ def setgeo(rundata):
     #  ioutarrivaltimes,ioutsurfacemax]
     
     # == fgmax.data values ==
-    rundata.fgmax_data.num_fgmax_val = 1
+    rundata.fgmax_data.num_fgmax_val = 2
     fgmax_grids = rundata.fgmax_data.fgmax_grids  # empty list to start
     # Now append to this list objects of class fgmax_tools.FGmaxGrid
     # specifying any fgmax grids.


### PR DESCRIPTION
The way fgmax values are handled has been updated in geoclaw. Previously, we had created our own fgmax module to track wind speed, in case we wanted to avoid running licrice. But it is now causing segfaults in some of the tests. It's unclear whether we just need to alter the test setup (b/c they depend on the standard fgmax_values.f90 module, or b/c our new fgmax_values_wind.f90 module is now incompatible. We could dig into it, but we never ended up using this functionality and probably won't anytime soon. So I'm just reverting back to using the default fgmax_values.f90 module. I'm also just reverting to the standard clawpack/geoclaw version of the travis spec, just to minimize differences.