### PR TITLE
fix the cells checked in bc2amr

### DIFF
--- a/src/2d/shallow/bc2amr.f90
+++ b/src/2d/shallow/bc2amr.f90
@@ -127,7 +127,7 @@ subroutine bc2amr(val,aux,nrow,ncol,meqn,naux, hx, hy, level, time,   &
 
         select case(mthbc(1))
             case(0) ! User defined boundary condition
-                ! only check columns that are not ghost cells
+                ! only check cells that are not ghost cells
                 max_bnd_val = maxval(abs(val(2, nxl+1, 1+nghost:ncol-nghost)))
                 if (max_bnd_val > mom_norm_thresh) then
                     write(0,"('Boundary velocity error: ',f16.8)") max_bnd_val
@@ -185,7 +185,7 @@ subroutine bc2amr(val,aux,nrow,ncol,meqn,naux, hx, hy, level, time,   &
 
         select case(mthbc(2))
             case(0) ! User defined boundary condition
-                ! only check columns that are not ghost cells
+                ! only check cells that are not ghost cells
                 max_bnd_val = maxval(abs(val(2, ibeg - 1, 1+nghost:ncol-nghost)))
                 if (max_bnd_val > mom_norm_thresh) then
                     write(0,"('Boundary velocity error: ',f16.8)") max_bnd_val
@@ -242,8 +242,8 @@ subroutine bc2amr(val,aux,nrow,ncol,meqn,naux, hx, hy, level, time,   &
 
         select case(mthbc(3))
             case(0) ! User defined boundary condition
-                ! only check rows that are not ghost cells
-                max_bnd_val = maxval(abs(val(3, 1+nghost:ncol-nghost, nyb+1)))
+                ! only check cells that are not ghost cells
+                max_bnd_val = maxval(abs(val(3, 1+nghost:nrow-nghost, nyb+1)))
                 if (max_bnd_val > mom_norm_thresh) then
                     write(0,"('Boundary velocity error: ',f16.8)") max_bnd_val
                     call exit(4)
@@ -302,8 +302,8 @@ subroutine bc2amr(val,aux,nrow,ncol,meqn,naux, hx, hy, level, time,   &
 
         select case(mthbc(4))
             case(0) ! User defined boundary condition
-                ! only check rows that are not ghost cells
-                max_bnd_val = maxval(abs(val(3, 1+nghost:ncol-nghost, jbeg - 1)))
+                ! only check cells that are not ghost cells
+                max_bnd_val = maxval(abs(val(3, 1+nghost:nrow-nghost, jbeg - 1)))
                 if (max_bnd_val > mom_norm_thresh) then
                     write(0,"('Boundary velocity error: ',f16.8)") max_bnd_val
                     call exit(5)


### PR DESCRIPTION
Fixes a typo where "ncol" was used when checking bottom and top boundaries, but "nrow" should have been.