### PR TITLE
Handle periodic BCs and large DEMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 xclaw
 xamr
 xgeoclaw
+xgeoclaw_omp
 xgeoclaw.dSYM
 *.html
 _output/

--- a/src/2d/shallow/bc2amr.f90
+++ b/src/2d/shallow/bc2amr.f90
@@ -116,6 +116,13 @@ subroutine bc2amr(val,aux,nrow,ncol,meqn,naux, hx, hy, level, time,   &
         return
     end if
 
+    ! Another case occurs when this grid covers only ghost cells (seems to happen only
+    ! when domain is periodic). In this case, we don't need to set anything and, if we
+    ! try, the array indexing will be out of bounds.
+    if (xlo_patch == xupper .or. xhi_patch == xlower .or. ylo_patch == yupper .or. yhi_patch == ylower) then
+        return
+    end if
+
     ! Each check has an initial check to ensure that the boundary is a real
     ! boundary condition and otherwise skips the code.  Otherwise 
     !-------------------------------------------------------
@@ -251,19 +258,7 @@ subroutine bc2amr(val,aux,nrow,ncol,meqn,naux, hx, hy, level, time,   &
                 nxr = max(int((xhi_patch - xupper + hxmarg) / hx), 0)
                 max_bnd_val = maxval(abs(val(3, 1+nxl:nrow-nxr, nyb+1)))
                 if (max_bnd_val > mom_norm_thresh) then
-                    print *, abs(val(3, 1:nrow, nyb+1))
-                    print *, abs(val(3, 1:nrow, nyb+2))
-                    write(0,"('nxl: ',i10)") nxl
-                    write(0,"('nxr: ',i10)") nxr
-                    write(0,"('nyb: ',i10)") nyb
-                    write(0,"('sizevalx: ',i10)") size(val, 2)
-                    write(0,"('sizevaly: ',i10)") size(val, 3)
-                    write(0,"('maxloc: ',i10)") maxloc(abs(val(3, 1+nxl:nrow-nxr, nyb+1)))
-                    write(0,"('ylo_patch: ',f16.8)") ylo_patch
-                    write(0,"('xlo_patch: ',f16.8)") xlo_patch
-                    write(0,"('yhi_patch: ',f16.8)") yhi_patch
-                    write(0,"('xhi_patch: ',f16.8)") xhi_patch
-                    write(0,"('Boundary velocity error south: ',e16.1)") max_bnd_val / 100
+                    write(0,"('Boundary velocity error south: ',f16.1)") max_bnd_val
                     call exit(4)
                 endif
 
@@ -323,15 +318,6 @@ subroutine bc2amr(val,aux,nrow,ncol,meqn,naux, hx, hy, level, time,   &
                 ! only check cells that are not ghost cells
                 nxl = max(int((xlower + hxmarg - xlo_patch) / hx), 0)
                 nxr = max(int((xhi_patch - xupper + hxmarg) / hx), 0)
-                write(0,"('nxl: ',i10)") nxl
-                write(0,"('nxr: ',i10)") nxr
-                write(0,"('jgeg: ',i10)") jbeg
-                write(0,"('sizevalx: ',i10)") size(val, 2)
-                write(0,"('sizevaly: ',i10)") size(val, 3)
-                write(0,"('ylo_patch: ',f16.8)") ylo_patch
-                write(0,"('xlo_patch: ',f16.8)") xlo_patch
-                write(0,"('yhi_patch: ',f16.8)") yhi_patch
-                write(0,"('xhi_patch: ',f16.8)") xhi_patch
                 max_bnd_val = maxval(abs(val(3, 1+nxl:nrow-nxr, jbeg - 1)))
                 if (max_bnd_val > mom_norm_thresh) then
                     write(0,"('Boundary velocity error north: ',f16.1)") max_bnd_val

--- a/src/2d/shallow/bc2amr.f90
+++ b/src/2d/shallow/bc2amr.f90
@@ -128,9 +128,11 @@ subroutine bc2amr(val,aux,nrow,ncol,meqn,naux, hx, hy, level, time,   &
         select case(mthbc(1))
             case(0) ! User defined boundary condition
                 ! only check cells that are not ghost cells
-                max_bnd_val = maxval(abs(val(2, nxl+1, 1+nghost:ncol-nghost)))
+                nyb = max(int((ylower + hymarg - ylo_patch) / hy), 0)
+                nyt = max(int((yhi_patch - yupper + hymarg) / hy), 0)
+                max_bnd_val = maxval(abs(val(2, nxl+1, nyb+1:ncol-nyt)))
                 if (max_bnd_val > mom_norm_thresh) then
-                    write(0,"('Boundary velocity error: ',f16.8)") max_bnd_val
+                    write(0,"('Boundary velocity error west: ',f16.1)") max_bnd_val
                     call exit(2)
                 endif
                 do j = 1, ncol
@@ -186,9 +188,11 @@ subroutine bc2amr(val,aux,nrow,ncol,meqn,naux, hx, hy, level, time,   &
         select case(mthbc(2))
             case(0) ! User defined boundary condition
                 ! only check cells that are not ghost cells
-                max_bnd_val = maxval(abs(val(2, ibeg - 1, 1+nghost:ncol-nghost)))
+                nyb = max(int((ylower + hymarg - ylo_patch) / hy), 0)
+                nyt = max(int((yhi_patch - yupper + hymarg) / hy), 0)
+                max_bnd_val = maxval(abs(val(2, ibeg - 1, 1+nyb:ncol-nyt)))
                 if (max_bnd_val > mom_norm_thresh) then
-                    write(0,"('Boundary velocity error: ',f16.8)") max_bnd_val
+                    write(0,"('Boundary velocity error east: ',f16.1)") max_bnd_val
                     call exit(3)
                 endif
                 do i = ibeg, nrow
@@ -243,9 +247,23 @@ subroutine bc2amr(val,aux,nrow,ncol,meqn,naux, hx, hy, level, time,   &
         select case(mthbc(3))
             case(0) ! User defined boundary condition
                 ! only check cells that are not ghost cells
-                max_bnd_val = maxval(abs(val(3, 1+nghost:nrow-nghost, nyb+1)))
+                nxl = max(int((xlower + hxmarg - xlo_patch) / hx), 0)
+                nxr = max(int((xhi_patch - xupper + hxmarg) / hx), 0)
+                max_bnd_val = maxval(abs(val(3, 1+nxl:nrow-nxr, nyb+1)))
                 if (max_bnd_val > mom_norm_thresh) then
-                    write(0,"('Boundary velocity error: ',f16.8)") max_bnd_val
+                    print *, abs(val(3, 1:nrow, nyb+1))
+                    print *, abs(val(3, 1:nrow, nyb+2))
+                    write(0,"('nxl: ',i10)") nxl
+                    write(0,"('nxr: ',i10)") nxr
+                    write(0,"('nyb: ',i10)") nyb
+                    write(0,"('sizevalx: ',i10)") size(val, 2)
+                    write(0,"('sizevaly: ',i10)") size(val, 3)
+                    write(0,"('maxloc: ',i10)") maxloc(abs(val(3, 1+nxl:nrow-nxr, nyb+1)))
+                    write(0,"('ylo_patch: ',f16.8)") ylo_patch
+                    write(0,"('xlo_patch: ',f16.8)") xlo_patch
+                    write(0,"('yhi_patch: ',f16.8)") yhi_patch
+                    write(0,"('xhi_patch: ',f16.8)") xhi_patch
+                    write(0,"('Boundary velocity error south: ',e16.1)") max_bnd_val / 100
                     call exit(4)
                 endif
 
@@ -303,9 +321,20 @@ subroutine bc2amr(val,aux,nrow,ncol,meqn,naux, hx, hy, level, time,   &
         select case(mthbc(4))
             case(0) ! User defined boundary condition
                 ! only check cells that are not ghost cells
-                max_bnd_val = maxval(abs(val(3, 1+nghost:nrow-nghost, jbeg - 1)))
+                nxl = max(int((xlower + hxmarg - xlo_patch) / hx), 0)
+                nxr = max(int((xhi_patch - xupper + hxmarg) / hx), 0)
+                write(0,"('nxl: ',i10)") nxl
+                write(0,"('nxr: ',i10)") nxr
+                write(0,"('jgeg: ',i10)") jbeg
+                write(0,"('sizevalx: ',i10)") size(val, 2)
+                write(0,"('sizevaly: ',i10)") size(val, 3)
+                write(0,"('ylo_patch: ',f16.8)") ylo_patch
+                write(0,"('xlo_patch: ',f16.8)") xlo_patch
+                write(0,"('yhi_patch: ',f16.8)") yhi_patch
+                write(0,"('xhi_patch: ',f16.8)") xhi_patch
+                max_bnd_val = maxval(abs(val(3, 1+nxl:nrow-nxr, jbeg - 1)))
                 if (max_bnd_val > mom_norm_thresh) then
-                    write(0,"('Boundary velocity error: ',f16.8)") max_bnd_val
+                    write(0,"('Boundary velocity error north: ',f16.1)") max_bnd_val
                     call exit(5)
                 endif
                 do j = jbeg, ncol

--- a/src/2d/shallow/set_eta_init.f90
+++ b/src/2d/shallow/set_eta_init.f90
@@ -30,8 +30,8 @@ subroutine set_eta_init(mbc,mx,my,xlow,ylow,dx,dy,t,veta)
     real(kind=8), intent(inout) :: veta(1-mbc:mx+mbc,1-mbc:my+mbc)
     
     ! Local
-    integer :: i,j,i1,i2,j1,j2,idtopo,jdtopo,kdtopo, &
-               index0_dtopowork,ij,m
+    integer :: i,j,i1,i2,j1,j2,idtopo,jdtopo,kdtopo,m
+    integer(kind=8) :: index0_dtopowork, ij
     real(kind=8) :: x,y
     real(kind=8) :: x1_lake,x2_lake,y1_lake,y2_lake, lake_level
 
@@ -94,7 +94,7 @@ subroutine set_eta_init(mbc,mx,my,xlow,ylow,dx,dy,t,veta)
             kdtopo = max(kdtopo,1)
           endif
 
-        index0_dtopowork = i0dtopo(m) + (kdtopo-1)*mxdtopo(m)*mydtopo(m)
+        index0_dtopowork = i0dtopo(m) + int(kdtopo-1, 8)*int(mxdtopo(m), 8)*int(mydtopo(m), 8)
         !write(6,*) '+++ index0_dtopowork = ',index0_dtopowork
 
         ! Adjust eta_init by dtopo on part of patch that overlaps dtopo.
@@ -111,7 +111,7 @@ subroutine set_eta_init(mbc,mx,my,xlow,ylow,dx,dy,t,veta)
                 idtopo = max(1, min(mxdtopo(m)-1, idtopo))
                 jdtopo = int(floor((yhidtopo(m)-y)/dydtopo(m))) + 1
                 jdtopo = max(1, min(mydtopo(m)-1, jdtopo))
-                ij = index0_dtopowork + (jdtopo-1)*mxdtopo(m) + idtopo-1
+                ij = index0_dtopowork + int(jdtopo-1, 8)*int(mxdtopo(m) + idtopo-1, 8)
 
                 veta(i,j) = veta(i,j) + dtopowork(ij)
 

--- a/src/2d/shallow/topo_update.f90
+++ b/src/2d/shallow/topo_update.f90
@@ -20,9 +20,9 @@ subroutine topo_update(t)
    real(kind=8), intent(in) ::t
 
    !locals
-   integer :: i,j,m,mt
-   integer :: ij,ij0,irank,idtopo1,idtopo2,jdtopo1,jdtopo2
-   integer :: ijll,ijlr,ijul,ijur
+   integer :: m,mt
+   integer :: irank,idtopo1,idtopo2,jdtopo1,jdtopo2
+   integer(kind=8) :: ij,ij0,i,j,ijll,ijlr,ijul,ijur
    real(kind=8) :: x,y,xl,xr,yu,yl,zll,zlr,zul,zur,dz12,dz1,dz2,dztotal
 
    if (t<minval(t0dtopo).or.topo_finalized.eqv..true.) then
@@ -60,8 +60,8 @@ subroutine topo_update(t)
           taudtopo(m) = 1.d0-max(0.d0,((t-tdtopo1(m))/dtdtopo(m)))
           taudtopo(m) = max(taudtopo(m),0.d0)
         endif
-      index0_dtopowork1(m) = i0dtopo(m) + (kdtopo1(m)-1)*mxdtopo(m)*mydtopo(m)
-      index0_dtopowork2(m) = i0dtopo(m) + (kdtopo2(m)-1)*mxdtopo(m)*mydtopo(m)
+      index0_dtopowork1(m) = i0dtopo(m) + (int(kdtopo1(m), 8)-1)*int(mxdtopo(m), 8)*int(mydtopo(m), 8)
+      index0_dtopowork2(m) = i0dtopo(m) + (int(kdtopo2(m), 8)-1)*int(mxdtopo(m), 8)*int(mydtopo(m), 8)
    enddo
 
 
@@ -97,11 +97,11 @@ subroutine topo_update(t)
          cycle
       endif
 
-      do j=1,mytopo(mt)
+      do j=1,int(mytopo(mt), 8)
          y = yhitopo(mt) - real(j-1,kind=8)*dytopo(mt)
-         do i=1,mxtopo(mt)
-            ij = i0topo(mt) + (j-1)*mxtopo(mt) + i -1
-            ij0 = i0topo0(mt) + (j-1)*mxtopo(mt) + i -1
+         do i=1,int(mxtopo(mt), 8)
+            ij = i0topo(mt) + (j-1)*int(mxtopo(mt), 8) + i -1
+            ij0 = i0topo0(mt) + (j-1)*int(mxtopo(mt), 8) + i -1
             x = xlowtopo(mt) +  real(i-1,kind=8)*dxtopo(mt)
             dztotal = 0.0
             do irank = 1,num_dtopo
@@ -133,10 +133,10 @@ subroutine topo_update(t)
                jdtopo2 = jdtopo1+1
 
                !indices for dtopo work array
-               ijll = index0_dtopowork1(m) + (jdtopo2-1)*mxdtopo(m) + idtopo1 -1
-               ijlr = index0_dtopowork1(m) + (jdtopo2-1)*mxdtopo(m) + idtopo2 -1
-               ijul = index0_dtopowork1(m) + (jdtopo1-1)*mxdtopo(m) + idtopo1 -1
-               ijur = index0_dtopowork1(m) + (jdtopo1-1)*mxdtopo(m) + idtopo2 -1
+               ijll = index0_dtopowork1(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
+               ijlr = index0_dtopowork1(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
+               ijul = index0_dtopowork1(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
+               ijur = index0_dtopowork1(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
 
                !find x,y,z values for bilinear
                !z may be from only 1 or 2 nodes for coincidently aligned grids
@@ -154,10 +154,10 @@ subroutine topo_update(t)
                dz1 = zll*(xr-x)*(yu-y) + zlr*(x-xl)*(yu-y) + zul*(xr-x)*(y-yl) + zur*(x-xl)*(y-yl)
 
                !indices for work array at later time
-               ijll = index0_dtopowork2(m) + (jdtopo2-1)*mxdtopo(m) + idtopo1 -1
-               ijlr = index0_dtopowork2(m) + (jdtopo2-1)*mxdtopo(m) + idtopo2 -1
-               ijul = index0_dtopowork2(m) + (jdtopo1-1)*mxdtopo(m) + idtopo1 -1
-               ijur = index0_dtopowork2(m) + (jdtopo1-1)*mxdtopo(m) + idtopo2 -1
+               ijll = index0_dtopowork2(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
+               ijlr = index0_dtopowork2(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
+               ijul = index0_dtopowork2(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
+               ijur = index0_dtopowork2(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
                zll = dtopowork(ijll)
                zlr = dtopowork(ijlr)
                zul = dtopowork(ijul)


### PR DESCRIPTION
This MR introduces new functionality:

1. Ability to handle periodic BCs when topo is netcdf. Previously this was not possible.
2. Also, handle the fact that periodic BCs can create patches with only ghost cells in them. This is not supposed to happen but does. Here we avoid any array indexing issues by avoiding setting the boundary cells for these patches. 
3. Allows large dems with greater than 2**31 -1 grid cells